### PR TITLE
feat(midi): Highlight buttons with duplicate values

### DIFF
--- a/midi/style.css
+++ b/midi/style.css
@@ -194,3 +194,8 @@ td input[type="color"] {
     font-size: 1em;
     cursor: pointer;
 }
+
+.duplicate-highlight {
+    border: 2px dashed #ff4d4d;
+    box-shadow: 0 0 10px #ff4d4d;
+}


### PR DESCRIPTION
Implements a feature to detect and highlight patches that share the same Program Change (PC) or Control Change (CC) values.

A new function, `highlightDuplicates()`, is added to `script.js`. It calculates which PC and CC values are used more than once and applies a `.duplicate-highlight` CSS class to the corresponding buttons.

This function is called on initial load and after any changes are saved from the edit table, ensuring the visual feedback is always current. The new CSS class adds a noticeable border and shadow to make the duplicates stand out.